### PR TITLE
refactor: remove unnecessary floating-point casts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,15 +61,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -177,9 +177,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.4"
+version = "4.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+checksum = "6320c6d1c98b6981da7bb2dcecbd0be9dc98d42165fa8326b21000f7dbfde6d0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.4"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
 dependencies = [
  "anstream",
  "anstyle",
@@ -839,9 +839,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -1104,9 +1104,9 @@ checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -39,16 +39,15 @@ pub fn generate(level: u8) -> Image {
 /// Simple implementation that doesn't do any interpolation,
 /// so higher LUT sizes will prove to be more accurate.
 pub fn correct_pixel(input: &[u8; 3], hald_clut: &Image, level: u8) -> [u8; 3] {
-    let level = level as f64;
+    let level = level as u32;
     let cube_size = level * level;
 
-    let modulo = 255.0 / (cube_size - 1.0);
-    let r = (input[0] as f64 / modulo).floor();
-    let g = (input[1] as f64 / modulo).floor();
-    let b = (input[2] as f64 / modulo).floor();
+    let r = input[0] as u32 * (cube_size - 1) / 255;
+    let g = input[1] as u32 * (cube_size - 1) / 255;
+    let b = input[2] as u32 * (cube_size - 1) / 255;
 
-    let x = ((r % cube_size) + (g % level) * cube_size).floor();
-    let y = ((b * level) + (g / level)).floor();
+    let x = (r % cube_size) + (g % level) * cube_size;
+    let y = (b * level) + (g / level);
 
     hald_clut.get_pixel(x as u32, y as u32).0
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -49,7 +49,7 @@ pub fn correct_pixel(input: &[u8; 3], hald_clut: &Image, level: u8) -> [u8; 3] {
     let x = (r % cube_size) + (g % level) * cube_size;
     let y = (b * level) + (g / level);
 
-    hald_clut.get_pixel(x as u32, y as u32).0
+    hald_clut.get_pixel(x, y).0
 }
 
 /// Correct an image with a hald clut identity in place.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -13,20 +13,20 @@ pub fn generate(level: u8) -> Image {
 
     let mut imgbuf = ImageBuffer::new(image_size, image_size);
 
-    let mut p = 0.0;
+    let mut p = 0u32;
     for blue in 0..cube_size {
         for green in 0..cube_size {
             for red in 0..cube_size {
-                let r = ((red as f64) / (cube_size - 1) as f64) * 255.0;
-                let g = ((green as f64) / (cube_size - 1) as f64) * 255.0;
-                let b = ((blue as f64) / (cube_size - 1) as f64) * 255.0;
+                let r = red * 255 / (cube_size - 1);
+                let g = green * 255 / (cube_size - 1);
+                let b = blue * 255 / (cube_size - 1);
                 let pixel = image::Rgb([r as u8, g as u8, b as u8]);
 
-                let x = p % image_size as f64;
-                let y = (p - x) / image_size as f64;
+                let x = p % image_size;
+                let y = (p - x) / image_size;
 
-                imgbuf.put_pixel(x as u32, y as u32, pixel);
-                p += 1.0;
+                imgbuf.put_pixel(x, y, pixel);
+                p += 1;
             }
         }
     }


### PR DESCRIPTION
The algorithm that generates the identity CLUT computes values using `f64`'s because the result is a fraction in the range [0.0, 1.0) and then multiplies this to convert it to a `u8`. This can be simplified by multiplying by 255 first and then using integer division.

This does not actually improve performance, I assume LLVM optimizes out the floating-point math.

It may be possible to do this kind of thing elsewhere, I wasn't sure as I don't actually know how the algorithms work.