### PR TITLE
feat: guess image type

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -13,6 +13,7 @@ use clap::{
 };
 use clap_complete::{generate, Shell};
 use dirs::cache_dir;
+use image::io::Reader;
 use lutgen::{
     identity::{self, correct_pixel},
     interpolation::*,
@@ -568,7 +569,14 @@ fn load_image<P: AsRef<Path>>(path: P) -> Image {
         spinners::Stream::Stderr,
     );
     let time = Instant::now();
-    let lut = image::open(path).expect("failed to open image").to_rgb8();
+    let lut = Reader::open(path)
+        .expect("failed to open image")
+        .with_guessed_format()
+        .expect("failed to guess image format")
+        .decode()
+        .expect("failed to decode image")
+        .to_rgb8();
+
     sp.stop_and_persist("✔", format!("Loaded {path:?} in {:?}", time.elapsed()));
     lut
 }


### PR DESCRIPTION
Previously lutgen-rs choked on files without an extension (or those that had a non-matching extension); I switched to using `image::io::Reader`'s  [`with_guessed_format`](https://docs.rs/image/0.23.10/image/io/struct.Reader.html#method.with_guessed_format), which tries to automatically guess the file type via magic bytes.