### PR TITLE
fix(studio): floor panel width to pixel grid to stop fractional-scali…

### DIFF
--- a/crates/studio/src/ui/left.rs
+++ b/crates/studio/src/ui/left.rs
@@ -5,6 +5,7 @@ use strum::VariantArray;
 
 use crate::palette::{lutgen_dir, DynamicPalette};
 use crate::state::LutAlgorithm;
+use crate::utils::floor_to_pixels;
 use crate::App;
 
 /// Helper to add a labeled slider with dynamic DragValue sizing.
@@ -89,10 +90,11 @@ impl PaletteFilterBox {
         let mut apply = false;
         let mut res = ui
             .group(|ui| {
+                let width = floor_to_pixels(ui, ui.available_width());
                 egui::Resize::default()
                     .resizable([true, false])
-                    .min_width(ui.available_width())
-                    .max_width(ui.available_width())
+                    .min_width(width)
+                    .max_width(width)
                     .with_stroke(false)
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
@@ -498,7 +500,7 @@ impl App {
                 .resizable(true)
                 .min_width(214.)
                 .show(ctx, |ui| {
-                    ui.take_available_width();
+                    ui.set_width(floor_to_pixels(ui, ui.available_width()));
                     egui::ScrollArea::vertical().show(ui, |ui| {
                         self.show_sidebar_inner(ui);
                     });

--- a/crates/studio/src/utils.rs
+++ b/crates/studio/src/utils.rs
@@ -3,6 +3,11 @@ use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
+pub fn floor_to_pixels(ui: &egui::Ui, points: f32) -> f32 {
+    let ppp = ui.ctx().pixels_per_point();
+    (points * ppp).floor() / ppp
+}
+
 /// Utility to wrap non-hashable types with their string impl
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Hashed<T: Clone + Debug>(pub T);


### PR DESCRIPTION
# fix(studio): side panel grows on its own under fractional scaling

Fixes #42

## Problem

Left panel slowly grows wider on its own, no dragging needed — just moving the mouse over the window is enough. Reported on Wayland (Hyprland/KDE, 1.25x) but it's not a Wayland thing. Happens anywhere scaling isn't 1.0 — Windows, macOS, web. X11 at 1.0 is fine, which is probably why the last fix for this didn't actually work for everyone.

## Root cause

`take_available_width()` gives an unrounded point value. Child widgets round it up to the nearest physical pixel under fractional scaling, so the content rect comes back slightly wider than it went in. That wider value gets stored and reused next frame. Repeat every frame, repaint on every mouse move, and you get visible creep.

## Fix

Floor the width to the pixel grid before it reaches child widgets:

```rust
// crates/studio/src/utils.rs
pub fn floor_to_pixels(ui: &egui::Ui, points: f32) -> f32 {
    let ppp = ui.ctx().pixels_per_point();
    (points * ppp).floor() / ppp
}
```

Used in the two spots that fill width from content:
- left `SidePanel`
- palette `egui::Resize`

Didn't touch `TopBottomPanel`/`CentralPanel` — they don't fill their resizable axis the same way, so not affected.

## Verification

Forced `pixels_per_point = 1.25`, continuous repaint, logged width per frame.

- Before: 198 → 706pt in ~4s, never stops
- After: settles at 198.4pt

Clean build + clippy, native and wasm32. Resize drag still works, still persists.